### PR TITLE
:wrench: Update GitHub Actions workflow dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,13 @@ on:
 jobs:
   release:
     name: Build, test, and release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 12
       - name: Install dependencies

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -8,13 +8,13 @@ on:
 jobs:
   release:
     name: Build website
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 12
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Updates `actions/checkout` from v1 to v4 in both GitHub Actions workflows.
- Updates `actions/setup-node` from v1 to v4 and moves workflows off the retired `ubuntu-18.04` runner.

Fixes #14
Fixes #15

## Test plan
- `python3` YAML parse for `.github/workflows/release.yml` and `.github/workflows/website.yml`
- `/tmp/actionlint/actionlint .github/workflows/release.yml .github/workflows/website.yml`
- `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci`
- `npm run build`
- `npx -y -p node@12 -c 'node --version && ./node_modules/.bin/tsc --version && npm run build'`

Note: `npm run test` was attempted locally after downloading Chromium, but this container cannot launch Chromium without a usable sandbox (`zygote_host_impl_linux.cc(116) No usable sandbox`). The workflow change itself is covered by YAML/actionlint validation and the build checks above.
